### PR TITLE
Bugfix/i18n navigation

### DIFF
--- a/src/app/[locale]/explore/clubs/components/ClubCard.tsx
+++ b/src/app/[locale]/explore/clubs/components/ClubCard.tsx
@@ -3,13 +3,13 @@
 import Button from "@/components/Button";
 import Icon from "@/components/Icon";
 import InstagramIcon from "@/components/socialIcon/InstagramIcon";
+import { Link } from "@/i18n/navigation";
 import cn from "@/lib/helpers/cn";
 import type { ClubItem } from "@/lib/types/club";
 import { StyleableFC } from "@/lib/types/misc";
 import { motion } from "motion/react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
-import Link from "next/link";
 import { useState } from "react";
 
 const ClubCard: StyleableFC<{

--- a/src/app/[locale]/explore/map/components/FacultyMap.tsx
+++ b/src/app/[locale]/explore/map/components/FacultyMap.tsx
@@ -2,13 +2,13 @@
 
 import Button from "@/components/Button";
 import Icon from "@/components/Icon";
+import { useRouter } from "@/i18n/navigation";
 import cn from "@/lib/helpers/cn";
 import { StyleableFC } from "@/lib/types/misc";
 import facultyMapEN from "@/public/map/Faculty-en.png";
 import facultyMapTH from "@/public/map/Faculty-th.png";
 import { useLocale, useTranslations } from "next-intl";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 const buildings = [

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -2,8 +2,8 @@
 
 import Button from "@/components/Button";
 import Icon from "@/components/Icon";
+import { useRouter } from "@/i18n/navigation";
 import { StyleableFC } from "@/lib/types/misc";
-import { useRouter } from "next/navigation";
 
 type BackButtonProps = {
   variants: "primary" | "secondary" | "tertiary" | "secondary-variant";

--- a/src/components/HomeButton.tsx
+++ b/src/components/HomeButton.tsx
@@ -1,6 +1,6 @@
 import Button from "@/components/Button";
 import Icon from "@/components/Icon";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 
 export default function HomeButton() {
   return (

--- a/src/components/Interactive.tsx
+++ b/src/components/Interactive.tsx
@@ -2,7 +2,7 @@
 
 import cn from "@/lib/helpers/cn";
 import type { StyleableFC } from "@/lib/types/misc";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 import type { ComponentProps, MouseEvent, ReactNode } from "react";
 import { useRef, useState } from "react";
 

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -2,8 +2,8 @@
 
 import Button from "@/components/Button";
 import Icon from "@/components/Icon";
+import { usePathname, useRouter } from "@/i18n/navigation";
 import { useLocale, useTranslations } from "next-intl";
-import { usePathname, useRouter } from "next/navigation";
 
 export default function LanguageSwitcher() {
   const locale = useLocale();
@@ -12,18 +12,8 @@ export default function LanguageSwitcher() {
   const t = useTranslations("Common.LanguageSwitcher");
   const nextLocale = locale === "th" ? "en" : "th";
   function handleSwitch() {
-    const segments = pathname.split("/");
-
-    if (!["th", "en"].includes(segments[1])) {
-      console.warn("Not a valid locale segment:", segments[1]); // check valid locale
-      return;
-    }
-
-    segments[1] = nextLocale;
-
-    router.push(segments.join("/"));
+    router.replace(pathname, { locale: nextLocale });
   }
-
   return (
     <Button
       Size="small"

--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -2,12 +2,12 @@
 
 import Button from "@/components/Button";
 import Icon from "@/components/Icon";
+import { Link, useRouter } from "@/i18n/navigation";
 import { signInWithGoogle } from "@/lib/firebase/auth";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
-import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useRef, useState } from "react";
 
 interface GoogleLoginBtnProps {

--- a/src/components/NavBarItem.tsx
+++ b/src/components/NavBarItem.tsx
@@ -2,8 +2,8 @@
 
 import Icon from "@/components/Icon";
 import Interactive from "@/components/Interactive";
+import { usePathname } from "@/i18n/navigation";
 import cn from "@/lib/helpers/cn";
-import { usePathname } from "next/navigation";
 
 export default function NavBarItem({
   icon,
@@ -15,10 +15,7 @@ export default function NavBarItem({
   href: string;
 }) {
   const pathname = usePathname();
-  const segments = pathname.split("/");
-  const pathWithoutLocale = "/" + segments.slice(2).join("/");
-  const isActive =
-    pathWithoutLocale === href || pathWithoutLocale.startsWith(href + "/");
+  const isActive = pathname === href || pathname.startsWith(href + "/");
   return (
     <Interactive
       href={href}


### PR DESCRIPTION
# Problem Statement
Right after login, I found that whenever I go to other routes, the locals only sticks to whatever locale was used before login.
Though, after refreshing the page, it seems to switches the locale for me.
The main issue is that it seems to be really inconsistent.

# Code Changes
- Change all possible components and pages to use the already-made i18n navigation in `/src/i18n/navigation.ts`
- Update middleware.ts to behave properly with the change (it duplicated the locale, which is handled by everything else instead)