### PR TITLE
Bugfix/explore clubs toggle

### DIFF
--- a/src/app/[locale]/explore/clubs/components/ClubCard.tsx
+++ b/src/app/[locale]/explore/clubs/components/ClubCard.tsx
@@ -2,6 +2,7 @@
 
 import Button from "@/components/Button";
 import Icon from "@/components/Icon";
+import Interactive from "@/components/Interactive";
 import InstagramIcon from "@/components/socialIcon/InstagramIcon";
 import cn from "@/lib/helpers/cn";
 import type { ClubItem } from "@/lib/types/club";
@@ -28,32 +29,44 @@ const ClubCard: StyleableFC<{
       <motion.div
         layout="position"
         className={cn(
-          "type-body-medium flex w-full items-center gap-3 p-3.5 transition-colors duration-200",
+          "type-body-medium flex w-full gap-3 transition-colors duration-200",
           isOpen && "bg-yellow/20"
         )}
       >
-        <Image src={logoURL} alt="" width={72} height={72} />
+        <Image
+          src={logoURL}
+          alt=""
+          width={72}
+          height={72}
+          className="m-3.5 mr-0"
+        />
         <motion.div
           animate={{ y: isOpen && club.description ? 22 : 0 }}
           transition={{ duration: 0.3, ease: "easeOut" }}
-          className="grid grow"
+          className="grid grow self-center"
         >
           <h3 className="type-title-medium truncate">{club.name}</h3>
           <motion.p
+            aria-hidden
             animate={{ opacity: isOpen ? 0 : 1 }}
             className="line-clamp-2"
           >
             {club.description}
           </motion.p>
         </motion.div>
-        <motion.button
-          animate={{ rotate: isOpen ? 180 : 0 }}
-          transition={{ duration: 0.3, ease: "easeOut" }}
+        <Interactive
+          title={t(`Clubs.Card.action.${isOpen ? "less" : "more"}`)}
           onClick={() => setIsOpen((isOpen) => !isOpen)}
-          className="cursor-pointer"
+          className="text-red shrink-0 px-4"
         >
-          <Icon name="expand_more" className="text-red" />
-        </motion.button>
+          <motion.div
+            animate={{ rotate: isOpen ? 180 : 0 }}
+            transition={{ duration: 0.3, ease: "easeOut" }}
+            className="w-fit"
+          >
+            <Icon name="expand_more" size={24} />
+          </motion.div>
+        </Interactive>
       </motion.div>
 
       <motion.div

--- a/src/app/[locale]/explore/clubs/components/ClubCard.tsx
+++ b/src/app/[locale]/explore/clubs/components/ClubCard.tsx
@@ -88,7 +88,7 @@ const ClubCard: StyleableFC<{
                 <Button Appearance="secondary" Size="x-small">
                   <span className="type-title-medium">
                     {t(`Map.Faculty.building.${club.boothPosition?.building}`)}
-                  </span>{" "}
+                  </span>
                 </Button>
               </div>
             )}

--- a/src/app/[locale]/explore/clubs/components/ClubCard.tsx
+++ b/src/app/[locale]/explore/clubs/components/ClubCard.tsx
@@ -3,7 +3,6 @@
 import Button from "@/components/Button";
 import Icon from "@/components/Icon";
 import InstagramIcon from "@/components/socialIcon/InstagramIcon";
-import { Link } from "@/i18n/navigation";
 import cn from "@/lib/helpers/cn";
 import type { ClubItem } from "@/lib/types/club";
 import { StyleableFC } from "@/lib/types/misc";
@@ -94,15 +93,14 @@ const ClubCard: StyleableFC<{
               </div>
             )}
             {igURL && (
-              <Link href={igURL}>
-                <Button
-                  Appearance="secondary"
-                  Size="small"
-                  title={t("Clubs.Card.action.instagram", { username })}
-                >
-                  <InstagramIcon />
-                </Button>
-              </Link>
+              <Button
+                Appearance="secondary"
+                Size="small"
+                title={t("Clubs.Card.action.instagram", { username })}
+                href={igURL}
+              >
+                <InstagramIcon />
+              </Button>
             )}
           </div>
         </motion.div>

--- a/src/app/[locale]/explore/clubs/components/FilteredResult.tsx
+++ b/src/app/[locale]/explore/clubs/components/FilteredResult.tsx
@@ -34,12 +34,12 @@ const FilteredResult: StyleableFC<{
         (g) =>
           g.items.length > 0 && (
             <div key={g.key} className={cn("mb-6", className)} style={style}>
-              <motion.p
+              <motion.h3
                 layout="position"
                 className="type-title-large text-red mb-4 text-center font-bold"
               >
                 {t(`List.title.${g.key}`)}
-              </motion.p>
+              </motion.h3>
               {g.items.map((item, i) => (
                 <div key={i}>{renderItem(item)}</div>
               ))}

--- a/src/app/[locale]/explore/clubs/components/FilteredResult.tsx
+++ b/src/app/[locale]/explore/clubs/components/FilteredResult.tsx
@@ -3,6 +3,7 @@
 import cn from "@/lib/helpers/cn";
 import type { ClubItem } from "@/lib/types/club";
 import { StyleableFC } from "@/lib/types/misc";
+import { motion } from "motion/react";
 import { useTranslations } from "next-intl";
 
 const FilteredResult: StyleableFC<{
@@ -33,9 +34,12 @@ const FilteredResult: StyleableFC<{
         (g) =>
           g.items.length > 0 && (
             <div key={g.key} className={cn("mb-6", className)} style={style}>
-              <p className="type-title-large text-red mb-4 text-center font-bold">
+              <motion.p
+                layout="position"
+                className="type-title-large text-red mb-4 text-center font-bold"
+              >
                 {t(`List.title.${g.key}`)}
-              </p>
+              </motion.p>
               {g.items.map((item, i) => (
                 <div key={i}>{renderItem(item)}</div>
               ))}

--- a/src/components/FaqCard.tsx
+++ b/src/components/FaqCard.tsx
@@ -36,7 +36,7 @@ const FaqCard: StyleableFC<{ questions: FaqQuestion }> = ({
         <Interactive
           title={t(isOpen ? "action.less" : "action.more")}
           onClick={() => setIsOpen((isOpen) => !isOpen)}
-          className="text-red px-4"
+          className="text-red shrink-0 px-4"
         >
           <motion.div
             animate={{ rotate: isOpen ? 180 : 0 }}

--- a/src/components/NavigationCard.tsx
+++ b/src/components/NavigationCard.tsx
@@ -28,7 +28,7 @@ const NavigationCard: StyleableFC<{
         )}
         style={style}
       >
-        <div className="relative text-center text-balance">
+        <div className="relative flex flex-col items-center text-center text-balance">
           <h2 className="type-chinese-medium mb-3">{title}</h2>
           <p
             className={cn(

--- a/src/components/SelectDropdown.tsx
+++ b/src/components/SelectDropdown.tsx
@@ -21,8 +21,8 @@ const SelectDropdown: StyleableFC<{
         onClick={() => setOpen(!open)}
         className="relative z-10 mb-2 h-11 w-full bg-white px-3 text-left outline-none"
       >
-        <div className="type-title-medium flex w-full items-center justify-between">
-          <div>{value || placeholder}</div>
+        <div className="flex w-full items-center justify-between">
+          <div className="type-title-medium">{value || placeholder}</div>
           <motion.div
             animate={{ rotate: open ? 180 : 0 }}
             transition={{ duration: 0.3, ease: "easeOut" }}
@@ -53,7 +53,7 @@ const SelectDropdown: StyleableFC<{
             {items.map((item, i) => (
               <Interactive
                 key={i}
-                className="type-title-medium flex h-11 w-full items-center bg-white px-4 transition-colors"
+                className="type-body-large flex h-11 w-full items-center bg-white px-4 transition-colors"
                 onClick={() => {
                   onChange(item);
                   setOpen(false);


### PR DESCRIPTION
Minor fixes in Explore and Explore Clubs

# Features

- Use Interactive in Club Card toggle

# Fixes

- FAQ Card toggle is off-center
- Navigation Card description is off-center if the title is wider than the max description width
  - Seen in Presentation
- Icon, option text are too bold in Select
- Club Panel headers jump (instead of animate) when toggling Club Cards
- Change Club Panel element from `<p>` to `<h3>`

# Other

- If a lot of other things are done, consider making it a separate heading (style chagnes, refactoring). Otherwise, using Other is fine.
- If there's nothing else done, you may remove this heading entirely.
