### PR TITLE
Bugfix/explore clubs retouch

### DIFF
--- a/src/app/[locale]/explore/map/components/BoothMap.tsx
+++ b/src/app/[locale]/explore/map/components/BoothMap.tsx
@@ -9,6 +9,7 @@ import type { StyleableFC } from "@/lib/types/misc";
 import Image, { StaticImageData } from "next/image";
 import { useRef, useState } from "react";
 import { useTranslations } from "next-intl";
+import { AnimatePresence, LayoutGroup, motion } from "motion/react";
 
 export interface BoothPosition {
   position: number;
@@ -70,20 +71,35 @@ const BoothMap: StyleableFC<BoothMapProps> = ({
         ))}
       </figure>
 
-      <div className="text-red mt-2 flex w-full items-center justify-start gap-2.5">
+      <div
+        className={cn(
+          "text-red mt-2 flex w-full items-center justify-start gap-2.5",
+          !selectedClub && "mb-8"
+        )}
+      >
         <Icon name="touch_app" size={24} />
         <p className="type-title-medium">{t("Building.instruction")}</p>
       </div>
 
-      {selectedClub && (
-        <div ref={scrollTargetRef} className="py-4">
-          <ClubCard club={selectedClub} />
-        </div>
-      )}
+      <LayoutGroup>
+        <AnimatePresence>
+          {selectedClub && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1, transition: { delay: 0.2 } }}
+              exit={{ opacity: 0 }}
+              ref={scrollTargetRef}
+              className="py-4"
+            >
+              <ClubCard club={selectedClub} />
+            </motion.div>
+          )}
+        </AnimatePresence>
 
-      <div>
-        <ClubListItem clubList={clubList} onClick={handleSelectClub} />
-      </div>
+        <motion.div layout="position">
+          <ClubListItem clubList={clubList} onClick={handleSelectClub} />
+        </motion.div>
+      </LayoutGroup>
     </div>
   );
 };

--- a/src/app/[locale]/explore/map/components/BoothMap.tsx
+++ b/src/app/[locale]/explore/map/components/BoothMap.tsx
@@ -43,10 +43,7 @@ const BoothMap: StyleableFC<BoothMapProps> = ({
 
   const handleClickBooth = (position: number) => {
     const club = clubList.find((c) => c.boothPosition?.position === position);
-    if (club) {
-      setSelectedClub(club);
-      scrollToCard();
-    }
+    if (club) setSelectedClub(club);
   };
 
   const handleSelectClub = (club: ClubItem) => {
@@ -55,10 +52,7 @@ const BoothMap: StyleableFC<BoothMapProps> = ({
   };
 
   return (
-    <div
-      className={cn("relative flex flex-col items-center gap-3", className)}
-      style={style}
-    >
+    <div className={cn("relative space-y-3", className)} style={style}>
       <figure className="relative">
         <Image src={image} alt={altText} priority />
 
@@ -81,15 +75,13 @@ const BoothMap: StyleableFC<BoothMapProps> = ({
         <p className="type-title-medium">{t("Building.instruction")}</p>
       </div>
 
-      <div ref={scrollTargetRef} className="h-1" />
-
       {selectedClub && (
-        <div className="my-4 w-full">
+        <div ref={scrollTargetRef} className="py-4">
           <ClubCard club={selectedClub} />
         </div>
       )}
 
-      <div className="flex w-full flex-col gap-1">
+      <div>
         <ClubListItem clubList={clubList} onClick={handleSelectClub} />
       </div>
     </div>

--- a/src/app/[locale]/explore/map/components/ClubListItem.tsx
+++ b/src/app/[locale]/explore/map/components/ClubListItem.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Interactive from "@/components/Interactive";
-import cn from "@/lib/helpers/cn";
 import { ClubItem } from "@/lib/types/club";
 import { StyleableFC } from "@/lib/types/misc";
 import Image from "next/image";
@@ -13,19 +12,21 @@ const ClubListItem: StyleableFC<{
 }> = ({ clubList, onClick, className, style }) => {
   const t = useTranslations("Map");
   return (
-    <div className={cn("space-y-4", className)} style={style}>
-      <p className="type-title-large text-red text-center font-bold">
+    <div className={className} style={style}>
+      <p className="type-title-large text-red mb-1 text-center font-bold">
         {t("Building.list")}
       </p>
       {clubList.map((club, index) => (
         <Interactive
           key={index}
-          className="type-title-medium flex w-full cursor-pointer items-center gap-2.5 px-2"
+          className="type-title-medium flex w-full cursor-pointer items-center gap-2.5 px-2 py-1"
           onClick={() => {
             onClick(club);
           }}
         >
-          <p className="text-red w-5">{club.boothPosition?.position}</p>
+          <p className="text-red min-w-5 text-end">
+            {club.boothPosition?.position}
+          </p>
           <Image
             src={`/clubs-logo/${club.logo}`}
             alt={club.name}
@@ -33,7 +34,7 @@ const ClubListItem: StyleableFC<{
             height={36}
             className="bg-white"
           />
-          <p className="w-full text-left text-black">{club.name}</p>
+          <p className="grow text-start text-black">{club.name}</p>
         </Interactive>
       ))}
     </div>

--- a/src/app/[locale]/explore/map/components/FacultyMap.tsx
+++ b/src/app/[locale]/explore/map/components/FacultyMap.tsx
@@ -73,7 +73,7 @@ const FacultyMap: StyleableFC = ({ className, style }) => {
 
       <div className="justify-left text-red flex w-full items-center gap-2.5 pb-3">
         <Icon name="touch_app" size={24} />
-        <p className="type-title-medium">{t("instruction")}</p>
+        <p className="type-title-medium text-balance">{t("instruction")}</p>
       </div>
 
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/[locale]/explore/map/components/FacultyMap.tsx
+++ b/src/app/[locale]/explore/map/components/FacultyMap.tsx
@@ -32,7 +32,7 @@ const buildings = [
 const FacultyMap: StyleableFC = ({ className, style }) => {
   const router = useRouter();
   const locale = useLocale();
-  const t = useTranslations("Map");
+  const t = useTranslations("Map.Faculty");
 
   const [selected, setSelected] = useState<string | null>(null);
   const [isTransitioning, setIsTransitioning] = useState(false);
@@ -57,7 +57,7 @@ const FacultyMap: StyleableFC = ({ className, style }) => {
       {isTransitioning && <div className="fixed inset-0 z-10 bg-black/30" />}
 
       <figure className="relative">
-        <Image src={facultyMap} alt={t("Faculty.alt")} priority />
+        <Image src={facultyMap} alt={t("alt")} priority />
         {buildings.map((building) => (
           <button
             key={building.key}
@@ -73,7 +73,7 @@ const FacultyMap: StyleableFC = ({ className, style }) => {
 
       <div className="justify-left text-red flex w-full items-center gap-2.5 pb-3">
         <Icon name="touch_app" size={24} />
-        <p className="type-title-medium">{t("Faculty.instruction")}</p>
+        <p className="type-title-medium">{t("instruction")}</p>
       </div>
 
       <div className="flex items-center justify-center gap-2">
@@ -85,7 +85,7 @@ const FacultyMap: StyleableFC = ({ className, style }) => {
             className="type-title-medium"
             onClick={() => handleClick(building.key)}
           >
-            {t(`Faculty.building.${building.key}`)}
+            {t(`building.${building.key}`)}
           </Button>
         ))}
       </div>

--- a/src/app/[locale]/explore/map/components/FacultyMap.tsx
+++ b/src/app/[locale]/explore/map/components/FacultyMap.tsx
@@ -76,7 +76,7 @@ const FacultyMap: StyleableFC = ({ className, style }) => {
         <p className="type-title-medium">{t("instruction")}</p>
       </div>
 
-      <div className="flex items-center justify-center gap-2">
+      <div className="flex flex-wrap items-center justify-center gap-2">
         {buildings.map((building) => (
           <Button
             key={building.key}


### PR DESCRIPTION
Some retouching in Explore Clubs

# Fixes

- Wrap Faculty Map building buttons in case of overflow
- Improve text balancing in Faculty Map instruction
- Club number width is not even in Club List Item
- Improve vertical spacing in Building Map
- Improve scroll and other animations in Building Map

