### PR TITLE
Fix/prediction checker admin

### DIFF
--- a/src/app/api/v1/prediction/[predictionId]/checker/route.ts
+++ b/src/app/api/v1/prediction/[predictionId]/checker/route.ts
@@ -30,8 +30,8 @@ export async function POST(
     }
 
     const solution = {
-      en: predictionSnap.data()?.solution.en.trim().toLowerCase,
-      th: predictionSnap.data()?.solution.th.trim().toLowerCase,
+      en: predictionSnap.data()?.solution.en.trim().toLowerCase(),
+      th: predictionSnap.data()?.solution.th.trim().toLowerCase(),
     };
 
     const answers = answersSnap.docs;

--- a/src/app/api/v1/prediction/score/route.ts
+++ b/src/app/api/v1/prediction/score/route.ts
@@ -60,6 +60,7 @@ export async function GET(request: NextRequest) {
     const groupsList = groups.map(({ group, name }) => {
       const usersInGroup = userData
         .filter((userDoc) => userDoc.data().group === group)
+        .filter((userDoc) => userDoc.data().role === "camper")
         .map((userDoc) => userDoc.id);
 
       const userCorrect = answersData.docs.filter((answerDoc) =>


### PR DESCRIPTION
# Fixes

-  filter only camper in  GET ```api/v1/prediction/score```
- add () in tolowerCase

.
